### PR TITLE
Fix hook name

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ import { minify } from 'uglify-es'
 export default function uglify (options = {}) {
 	return {
 		name: 'uglify',
-		transformBundle (code) {
+		renderChunk (code) {
 			const result = minify(
 				code,
 				Object.assign({ sourceMap: { url: 'out.js.map' } }, options ) // force sourcemap creation


### PR DESCRIPTION
Fix (!) The "transformBundle" hook used by plugin uglify is deprecated. The "renderChunk" hook should be used instead.